### PR TITLE
Added saving/updaing Circle CI context.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+
+jobs:
+  co:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/golang:1.16.
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+      - run:
+          name: Install Dependencies
+          command: go mod tidy
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - persist_to_workspace:
+          root: .
+          paths: [./* ]
+  rotate-iam-key:
+    docker:
+      - image: kohirens/iam-user-key-rotator:0.1.0
+        auth:
+          username: ${DH_USER}
+          password: ${DH_PASS}
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: 'IAM key/pair rotator'
+          command: |
+            './iam-user-key-rotator --circleci ${CIRCLE_TOKEN}'
+
+workflows:
+  pull-request:
+    jobs:
+      - co
+      - rotate-iam-key:
+          requires: [ co ]
+          context: orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   co:
     working_directory: ~/repo
     docker:
-      - image: circleci/golang:1.16.
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - restore_cache:
@@ -17,12 +17,17 @@ jobs:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+      - run:
+          name: Run tests
+          command: |
+            mkdir -p /tmp/test-reports
+            gotestsum --junitfile /tmp/test-reports/unit-tests.xml
       - persist_to_workspace:
           root: .
           paths: [./* ]
   rotate-iam-key:
     docker:
-      - image: kohirens/iam-user-key-rotator:0.1.0
+      - image: circleci/golang:1.17
         auth:
           username: ${DH_USER}
           password: ${DH_PASS}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
 workflows:
   pull-request:
     jobs:
-      - co
+      - co:
+          context: [ testing ]
       - rotate-iam-key:
           requires: [ co ]
-          context: orb-publishing
+          context: [ orb-publishing, testing ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+attach: &attach
+  - attach_workspace:
+      at: .
 jobs:
   co:
     working_directory: ~/repo
@@ -17,6 +20,19 @@ jobs:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+      - persist_to_workspace:
+          root: .
+          paths: [./* ]
+  test:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/golang:1.17
+    steps:
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
       - run:
           name: Run tests
           command: |
@@ -25,10 +41,7 @@ jobs:
       - store_artifacts:
           path: /tmp/test-reports
           destination: artifact-file
-      - persist_to_workspace:
-          root: .
-          paths: [./* ]
-  rotate-iam-key:
+  check-iam-key:
     docker:
       - image: circleci/golang:1.17
         auth:
@@ -37,17 +50,22 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
       - run:
           name: 'IAM key/pair rotator'
           command: |
             go build
-            ./iam-user-key-rotator --circleci "${CIRCLE_TOKEN}"
+            ./iam-user-key-rotator --region "us-east-2" --circleci "${CIRCLE_TOKEN}"
 
 workflows:
   wip:
     jobs:
-      - co:
+      - co
+      - test:
+          requires: [ co ]
           context: [ testing ]
-      - rotate-iam-key:
+      - check-iam-key:
           requires: [ co ]
           context: [ orb-publishing, testing ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           command: |
             mkdir -p /tmp/test-reports
             gotestsum --junitfile /tmp/test-reports/unit-tests.xml
+      - store_artifacts:
+          path: /tmp/test-reports
+          destination: artifact-file
       - persist_to_workspace:
           root: .
           paths: [./* ]
@@ -37,10 +40,11 @@ jobs:
       - run:
           name: 'IAM key/pair rotator'
           command: |
-            './iam-user-key-rotator --circleci ${CIRCLE_TOKEN}'
+            go build
+            ./iam-user-key-rotator --circleci "${CIRCLE_TOKEN}"
 
 workflows:
-  pull-request:
+  wip:
     jobs:
       - co:
           context: [ testing ]

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -12,6 +12,10 @@ services:
             context: '..'
             target: 'dev'
         image: 'kohirens/iam-user-key-rotator'
+        networks:
+            roto:
+                aliases:
+                    - 'rotate'
         volumes:
             - '../:/home/${USER_NAME}/src/${REPO}'
             - '~/.ssh/known_hosts:/home/${USER_NAME}/.ssh/known_hosts'
@@ -22,6 +26,10 @@ services:
 #        container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
         image: localstack/localstack
         network_mode: bridge
+        networks:
+            roto:
+                aliases:
+                    - 'localstack'
         ports:
 #            - "127.0.0.1:53:53"                # only required for Pro
 #            - "127.0.0.1:53:53/udp"            # only required for Pro
@@ -41,21 +49,8 @@ services:
             - "localstack:/tmp/localstack"
             - "/var/run/docker.sock:/var/run/docker.sock"
             - './local-stack/init-aws.sh:/docker-entrypoint-initaws.d/init-aws.sh'
+            - './local-stack/auto-roto-policy.json:/auto-roto-policy.json'
             - '../testdata:/test-tmp'
-
-# alias laws='aws --endpoint-url=http://localstack:4566'
-    awscli:
-        depends_on:
-            - localstack
-        build:
-            args:
-                USER_NAME: '${USER_NAME}'
-                REPO: '${REPO}'
-            dockerfile: '.docker/aws-cli/Dockerfile'
-            context: '..'
-        volumes:
-            - "./aws-cli/config:/root/.aws/config"
-            - "./aws-cli/credentials:/root/.aws/credentials"
 
 volumes:
     vscode: null
@@ -63,4 +58,4 @@ volumes:
     localstack: null
 
 networks:
-    roro: null
+    roto: null

--- a/.docker/local-stack/auto-roto-policy.json
+++ b/.docker/local-stack/auto-roto-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "iam:DeleteAccessKey",
+        "iam:CreateAccessKey",
+        "iam:ListAccessKeys"
+      ],
+      "Resource": "arn:aws:iam::000000000000:user/auto-roto"
+    }
+  ]
+}

--- a/.docker/local-stack/init-aws.sh
+++ b/.docker/local-stack/init-aws.sh
@@ -1,2 +1,3 @@
 awslocal iam create-user --user-name auto-roto
 awslocal iam create-access-key --user-name auto-roto > /test-tmp/access-key-secret-auto-roto.json
+awslocal iam put-user-policy --user-name auto-roto --policy-name YourPolicyName --policy-document file:///auto-roto-policy.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@
 # Files
 # -----
 /testdata/access-key-secret-auto-roto.json
-iam-user-key-rotator.exe
-new-aws-access*.csv
+/iam-user-key-rotator
+/iam-user-key-rotator.exe

--- a/error.go
+++ b/error.go
@@ -1,7 +1,9 @@
 package main
 
 var errors = struct {
-	regionMissing string
+	regionMissing,
+	updateCiContextErr string
 }{
-	regionMissing: "the -region flag is required and must not be an empty string",
+	regionMissing:      "the -region flag is required and must not be an empty string",
+	updateCiContextErr: "failed to update context: %v",
 }

--- a/flag.go
+++ b/flag.go
@@ -28,7 +28,7 @@ func (af *applicationFlags) define() {
 	appFlags.region = flag.String("region", "", flagUsages["region"])
 	appFlags.filename = flag.String("filename", "new-aws-access-key.json", flagUsages["filename"])
 	appFlags.profile = flag.String("profile", "", flagUsages["profile"])
-	appFlags.profile = flag.String("circleci", "", flagUsages["circleci"])
+	appFlags.circleci = flag.String("circleci", "", flagUsages["circleci"])
 }
 
 // check Verify that all flags are set appropriately.

--- a/flag.go
+++ b/flag.go
@@ -9,6 +9,7 @@ import (
 type applicationFlags struct {
 	maxDaysAllowed,
 	maxKeysAllowed *int
+	circleci,
 	region,
 	filename,
 	profile *string
@@ -27,6 +28,7 @@ func (af *applicationFlags) define() {
 	appFlags.region = flag.String("region", "", flagUsages["region"])
 	appFlags.filename = flag.String("filename", "new-aws-access-key.json", flagUsages["filename"])
 	appFlags.profile = flag.String("profile", "", flagUsages["profile"])
+	appFlags.profile = flag.String("circleci", "", flagUsages["circleci"])
 }
 
 // check Verify that all flags are set appropriately.

--- a/flagman.go
+++ b/flagman.go
@@ -8,4 +8,5 @@ var flagUsages = map[string]string{
 	"maxKeysAllowed": "[maxKeysAllowed] int\n\tAn integer representing the maximum number of keys that should exist on an IAM user.",
 	"filename":       "[filename] string\n\tPath of a file to store a new IAM key/secret pair.",
 	"region":         "<region> string\n\tAn AWS region.",
+	"circleci":       "[circleci] string\n\tCircle CI personal token used to update context variables.",
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"time"
 )
@@ -163,7 +164,23 @@ func main() {
 			return
 		}
 
-		saveToLocalProfile(newKey)
+		hClient := &http.Client{}
+
+		saveMode := ""
+		var saveErr error
+		switch saveMode {
+		case "circleci":
+			saveErr = updateCircleCIContextVar("", "", "", hClient)
+
+		default:
+			saveErr = saveToLocalProfile(newKey)
+		}
+
+		if saveErr != nil {
+			mainErr = saveErr
+			return
+		}
+
 		log.Println("new key saved to local profile")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 				SigningRegion: region,
 			}, nil
 		})
+		hClient = &mockHttpClient{0}
 		runAppMain()
 	}
 
@@ -72,6 +73,7 @@ func TestFlags(tester *testing.T) {
 	}{
 		{"noFlags", 1, []string{}},
 		{"withRegion", 0, []string{"-region", "us-east-2"}},
+		{"withCircleSuccess", 0, []string{"-region", "us-east-2", "--circleci", "1234"}},
 	}
 
 	for _, test := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -22,9 +22,6 @@ const (
 	dirMode     = 0700
 )
 
-// awsConfigOpts shorthand to set an array of config.LoadOptionsFunc to override defaults
-type awsConfigOpts []func(*config.LoadOptions) error
-
 func TestMain(m *testing.M) {
 	// Only runs when this environment variable is set. Allows testing the main program in a sub process.
 	if _, ok := os.LookupEnv(subCmdFlags); ok {

--- a/savecirclecicontext.go
+++ b/savecirclecicontext.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type httpCommunicator interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func updateCircleCIContextVar(name, val, token string, client httpCommunicator) error {
+	url := "https://circleci.com/api/v2/context/%7Bcontext-id%7D/environment-variable/" + name
+
+	payload := strings.NewReader("{\"value\":\"" + val + "\"}")
+
+	req, _ := http.NewRequest("PUT", url, payload)
+
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("authorization", "Basic "+token)
+
+	res, _ := client.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf(errors.updateCiContextErr, string(body))
+	}
+
+	return nil
+}

--- a/savecirclecicontext.go
+++ b/savecirclecicontext.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -28,6 +29,19 @@ func updateCircleCIContextVar(name, val, token string, client httpCommunicator) 
 
 	if res.StatusCode != 200 {
 		return fmt.Errorf(errors.updateCiContextErr, string(body))
+	}
+
+	return nil
+}
+
+// saveToCircleContext
+func saveToCircleContext(creds *iam.CreateAccessKeyOutput, cciToken string) error {
+	if err := updateCircleCIContextVar(keyVarName, *creds.AccessKey.AccessKeyId, cciToken, hClient); err != nil {
+		return err
+	}
+
+	if err := updateCircleCIContextVar(secretVarName, *creds.AccessKey.SecretAccessKey, cciToken, hClient); err != nil {
+		return err
 	}
 
 	return nil

--- a/savecirclecicontext_test.go
+++ b/savecirclecicontext_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type mockHttpClient struct {
+	ResponseType int
+}
+
+func (mhc *mockHttpClient) Do(req *http.Request) (*http.Response, error) {
+	switch mhc.ResponseType {
+	case 1:
+		return &http.Response{StatusCode: 400, Body: ioutil.NopCloser(strings.NewReader("err"))}, nil
+	default:
+		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(""))}, nil
+	}
+}
+
+func TestUpdateCircleCIContextVar(tester *testing.T) {
+	cases := []struct {
+		name   string
+		want   error
+		client httpCommunicator
+	}{
+		{"updateFails", fmt.Errorf(errors.updateCiContextErr, "err"), &mockHttpClient{1}},
+		{"updateSucceeds", nil, &mockHttpClient{0}},
+	}
+
+	for _, test := range cases {
+		tester.Run(test.name, func(t *testing.T) {
+			got := updateCircleCIContextVar("", "", "", test.client)
+			// Had to extract the error messages a compare them.
+			// Handle nil case separately
+			if (got != nil && got.Error() != test.want.Error()) || (got == nil && got != test.want) {
+				t.Errorf("want %v, got %v", test.want, got)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
You can use this in a CI pipeline to auto-rotate the very IAM key you use to connect to the AWS API, deploy IaC, etc.